### PR TITLE
Windows build

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,5 +1,4 @@
 cpp_flags = Split('''-std=c++1y 
-                     -Wno-c++98-compat 
                      -O0 
                      -g 
                      -fcolor-diagnostics''')


### PR DESCRIPTION
Removed the cl.exe incompatible option. It still has warnings but now compiles.

Before:


```
U:\petulant-avenger>SCons
scons: Reading SConscript files ...
scons: done reading SConscript files.
scons: Building targets ...
cl /FoIO.obj /c IO.cc -std=c++1y -Wno-c++98-compat -O0 -g -fcolor-diagnostics /n
ologo
cl : Command line error D8021 : invalid numeric argument '/Wno-c++98-compat'
scons: *** [IO.obj] Error 2
scons: building terminated because of errors.
```

after

```
U:\petulant-avenger>scons
scons: Reading SConscript files ...
scons: done reading SConscript files.
scons: Building targets ...
cl /FoIO.obj /c IO.cc -std=c++1y -O0 -g -fcolor-diagnostics /nologo
cl : Command line warning D9002 : ignoring unknown option '-std=c++1y'
cl : Command line warning D9002 : ignoring unknown option '-O0'
cl : Command line warning D9002 : ignoring unknown option '-g'
cl : Command line warning D9002 : ignoring unknown option '-fcolor-diagnostics'
IO.cc
C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\INCLUDE\xlocale(337) : wa
rning C4530: C++ exception handler used, but unwind semantics are not enabled. S
pecify /EHsc
cl /FoMain.obj /c Main.cc -std=c++1y -O0 -g -fcolor-diagnostics /nologo
cl : Command line warning D9002 : ignoring unknown option '-std=c++1y'
cl : Command line warning D9002 : ignoring unknown option '-O0'
cl : Command line warning D9002 : ignoring unknown option '-g'
cl : Command line warning D9002 : ignoring unknown option '-fcolor-diagnostics'
Main.cc
C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\INCLUDE\xlocale(337) : wa
rning C4530: C++ exception handler used, but unwind semantics are not enabled. S
pecify /EHsc
link /nologo /OUT:RunMe.exe Main.obj IO.obj
scons: done building targets.
```

